### PR TITLE
Disable guard SingleSpaceBeforeFirstArg

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -106,6 +106,9 @@ RescueModifier:
 SingleLineBlockParams:
   Enabled: false
 
+SingleSpaceBeforeFirstArg:
+  Enabled: false
+
 SingleLineMethods:
   Enabled: false
 


### PR DESCRIPTION
Disable the `SingleSpaceBeforeFirstArg` guard, since somethimes it's nice to align stuff (e.g. in `routes.rb`) and some people prefer

```
get  :foo
post :bar 
```

over

```
 get :foo 
post :bar 
```
